### PR TITLE
Withdraw Functionality - FIXES: https://github.com/Explore-Beyond-Innovations/ZeroCheck_Contracts/issues/10

### DIFF
--- a/src/EventRewardManager.sol
+++ b/src/EventRewardManager.sol
@@ -24,6 +24,9 @@ contract EventRewardManager is Ownable {
 
   mapping(uint256 => TokenReward) public eventTokenRewards;
 
+  //Minimum wait time required before the unclaimed reward withdrawal operation can be performed
+  uint256 public constant WITHDRAWAL_TIMEOUT = 30 days;
+
   event TokenRewardCreated(
     uint256 indexed eventId,
     address indexed eventManager,
@@ -34,6 +37,14 @@ contract EventRewardManager is Ownable {
 
   event TokenRewardUpdated(
     uint256 indexed eventId, address indexed eventManager, uint256 indexed newRewardAmount
+  );
+
+  event TokenRewardWithdrawn(
+    uint256 indexed eventId, address indexed eventManager, uint256 indexed amount
+  );
+
+  event TokenRewardCancelled(
+    uint256 indexed eventId, address indexed eventManager, uint256 indexed amount
   );
 
   constructor(address _eventManagerAddress) Ownable(msg.sender) {
@@ -133,4 +144,6 @@ contract EventRewardManager is Ownable {
     IERC20 token = IERC20(eventReward.tokenAddress);
     require(token.transfer(_recipient, _participantReward), "Token distribution failed");
   }
+
+  
 }

--- a/src/EventRewardManager.sol
+++ b/src/EventRewardManager.sol
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import { IERC20 } from "../lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import { Ownable } from "../lib/openzeppelin-contracts/contracts/access/Ownable.sol";
+import "../src/EventManager.sol";
+
+contract EventRewardManager is Ownable {
+  EventManager public eventManager;
+
+  enum TokenType {
+    NONE,
+    USDC,
+    WLD,
+    NFT
+  }
+
+  struct TokenReward {
+    address eventManager;
+    address tokenAddress;
+    TokenType tokenType;
+    uint256 rewardAmount;
+  }
+
+  mapping(uint256 => TokenReward) public eventTokenRewards;
+
+  event TokenRewardCreated(
+    uint256 indexed eventId,
+    address indexed eventManager,
+    address tokenAddress,
+    TokenType tokenType,
+    uint256 indexed rewardAmount
+  );
+
+  event TokenRewardUpdated(
+    uint256 indexed eventId, address indexed eventManager, uint256 indexed newRewardAmount
+  );
+
+  constructor(address _eventManagerAddress) Ownable(msg.sender) {
+    eventManager = EventManager(_eventManagerAddress);
+  }
+
+  function checkZeroAddress() internal view {
+    if (msg.sender == address(0)) revert("Zero address detected!");
+  }
+
+  function checkEventIsValid(uint256 _eventId) internal view {
+    if (eventManager.getEvent(_eventId).creator == address(0x0)) {
+      revert("Event does not exist");
+    }
+  }
+
+  // Create token-based event rewards
+  function createTokenReward(
+    uint256 _eventId,
+    TokenType _tokenType,
+    address _tokenAddress,
+    uint256 _rewardAmount
+  )
+    external
+    onlyOwner
+  {
+    checkZeroAddress();
+
+    checkEventIsValid(_eventId);
+
+    if (_tokenAddress == address(0)) revert("Zero token address detected");
+
+    if (_rewardAmount == 0) revert("Zero amount detected");
+
+    if (_tokenType != TokenType.USDC && _tokenType != TokenType.WLD) {
+      revert("Invalid token type");
+    }
+
+    eventTokenRewards[_eventId] = TokenReward({
+      eventManager: msg.sender,
+      tokenAddress: _tokenAddress,
+      tokenType: _tokenType,
+      rewardAmount: _rewardAmount
+    });
+
+    // Transfer tokens from event manager to contract
+    IERC20 token = IERC20(_tokenAddress);
+    require(token.transferFrom(msg.sender, address(this), _rewardAmount), "Token transfer failed");
+
+    emit TokenRewardCreated(_eventId, msg.sender, _tokenAddress, _tokenType, _rewardAmount);
+  }
+
+  // Update token-based event reward amount
+  function updateTokenReward(uint256 _eventId, uint256 _amount) external {
+    checkZeroAddress();
+
+    checkEventIsValid(_eventId);
+
+    TokenReward storage eventReward = eventTokenRewards[_eventId];
+
+    if (eventReward.eventManager != msg.sender) {
+      revert("Only event manager allowed");
+    }
+
+    eventReward.rewardAmount += _amount;
+
+    IERC20 token = IERC20(eventReward.tokenAddress);
+    require(token.transferFrom(msg.sender, address(this), _amount), "Token transfer failed");
+
+    emit TokenRewardUpdated(_eventId, msg.sender, _amount);
+  }
+
+  // Function to distribute tokens to event participants
+  function distributeTokenReward(
+    uint256 _eventId,
+    address _recipient,
+    uint256 _participantReward
+  )
+    external
+    onlyOwner
+  {
+    checkEventIsValid(_eventId);
+
+    TokenReward storage eventReward = eventTokenRewards[_eventId];
+
+    if (eventReward.tokenType != TokenType.USDC && eventReward.tokenType == TokenType.WLD) {
+      revert("No event token reward");
+    }
+
+    if (_participantReward > eventReward.rewardAmount) {
+      revert("Insufficient reward amount");
+    }
+
+    eventReward.rewardAmount -= _participantReward;
+
+    // Transfer tokens to participant
+    IERC20 token = IERC20(eventReward.tokenAddress);
+    require(token.transfer(_recipient, _participantReward), "Token distribution failed");
+  }
+}

--- a/src/EventRewardManager.sol
+++ b/src/EventRewardManager.sol
@@ -240,7 +240,7 @@ event TokenRewardCreated(
     userTokenRewards[_eventId][msg.sender] = 0;
     hasClaimedTokenReward[_eventId][msg.sender] = true;
 
-    eventReward.claimedAmount += _participantReward;
+    eventReward.claimedAmount += rewardAmount;
 
     // Transfer tokens to participant
     IERC20 token = IERC20(eventReward.tokenAddress);
@@ -269,13 +269,15 @@ event TokenRewardCreated(
     }
 
     uint256 remainingReward = eventReward.rewardAmount - eventReward.claimedAmount;
-    eventReward.rewardAmount = eventReward.claimedAmount;
     bool cancelled = false;
 
     // If no rewards have been claimed, cancel the event reward
     if (eventReward.claimedAmount == 0) {
-      eventReward.isCancelled = true;
-      cancelled = true;
+        eventReward.isCancelled = true;
+        cancelled = true;
+        eventReward.rewardAmount = 0;
+    } else {
+        eventReward.rewardAmount = eventReward.claimedAmount;
     }
 
     IERC20 token = IERC20(eventReward.tokenAddress);

--- a/src/EventRewardManager.sol
+++ b/src/EventRewardManager.sol
@@ -150,31 +150,6 @@ contract EventRewardManager is Ownable {
   }
 
   // Function to withdraw unclaimed rewards after timeout period
-  // function withdrawUnclaimedRewards(uint256 _eventId) external {
-  //   checkEventIsValid(_eventId);
-
-  //   TokenReward storage eventReward = eventTokenRewards[_eventId];
-
-  //   if (eventReward.eventManager != msg.sender) {
-  //     revert("Only event manager allowed");
-  //   }
-
-  //   if (block.timestamp < eventReward.createdAt + WITHDRAWAL_TIMEOUT) {
-  //     revert("Withdrawal timeout not reached");
-  //   }
-
-  //   if (eventReward.isCancelled) {
-  //     revert("Event reward has been cancelled");
-  //   }
-
-  //   uint256 unclaimedAmount = eventReward.rewardAmount;
-  //   eventReward.rewardAmount = 0;
-
-  //   IERC20 token = IERC20(eventReward.tokenAddress);
-  //   require(token.transfer(msg.sender, unclaimedAmount), "Token withdrawal failed");
-
-  //   emit TokenRewardWithdrawn(_eventId, msg.sender, unclaimedAmount);
-  // }
 
   function withdrawUnclaimedRewards(uint256 _eventId) external {
     checkZeroAddress();
@@ -203,6 +178,7 @@ contract EventRewardManager is Ownable {
     emit TokenRewardWithdrawn(_eventId, msg.sender, remainingReward);
   }
 
+  // Function to cancel and claim unclaimed rewards after a duration of 30 days 
   function cancelAndReclaimReward(uint256 _eventId) external {
     checkZeroAddress();
     checkEventIsValid(_eventId);

--- a/src/EventRewardManager.sol
+++ b/src/EventRewardManager.sol
@@ -32,8 +32,7 @@ contract EventRewardManager is Ownable {
   //Minimum wait time required before the unclaimed reward withdrawal operation can be performed
   uint256 public constant WITHDRAWAL_TIMEOUT = 30 days;
 
-
-event TokenRewardCreated(
+  event TokenRewardCreated(
     uint256 indexed eventId,
     address indexed eventManager,
     address tokenAddress,
@@ -45,7 +44,9 @@ event TokenRewardCreated(
     uint256 indexed eventId, address indexed eventManager, uint256 indexed newRewardAmount
   );
 
-  event TokenRewardWithdrawn(uint256 indexed eventId, address indexed eventManager, uint256 indexed amount, bool cancelled);
+  event TokenRewardWithdrawn(
+    uint256 indexed eventId, address indexed eventManager, uint256 indexed amount, bool cancelled
+  );
 
   event TokenRewardDistributed(uint256 indexed eventId, address indexed recipient, uint256 amount);
 
@@ -96,7 +97,7 @@ event TokenRewardCreated(
       tokenAddress: _tokenAddress,
       tokenType: _tokenType,
       rewardAmount: _rewardAmount,
-      claimedAmount: 0,  // Initialize claimed amount to 0
+      claimedAmount: 0, // Initialize claimed amount to 0
       createdAt: block.timestamp,
       isCancelled: false
     });
@@ -249,7 +250,8 @@ event TokenRewardCreated(
     emit TokenRewardClaimed(_eventId, msg.sender, rewardAmount);
   }
 
-  // Function to withdraw unclaimed rewards after timeout period and cancel the event reward, if the reward have been claimed
+  // Function to withdraw unclaimed rewards after timeout period and cancel the event reward, if the
+  // reward have been claimed
   function withdrawUnclaimedRewards(uint256 _eventId) external {
     checkZeroAddress();
     checkEventIsValid(_eventId);
@@ -273,11 +275,11 @@ event TokenRewardCreated(
 
     // If no rewards have been claimed, cancel the event reward
     if (eventReward.claimedAmount == 0) {
-        eventReward.isCancelled = true;
-        cancelled = true;
-        eventReward.rewardAmount = 0;
+      eventReward.isCancelled = true;
+      cancelled = true;
+      eventReward.rewardAmount = 0;
     } else {
-        eventReward.rewardAmount = eventReward.claimedAmount;
+      eventReward.rewardAmount = eventReward.claimedAmount;
     }
 
     IERC20 token = IERC20(eventReward.tokenAddress);

--- a/src/EventRewardManager.sol
+++ b/src/EventRewardManager.sol
@@ -249,7 +249,7 @@ event TokenRewardCreated(
     emit TokenRewardClaimed(_eventId, msg.sender, rewardAmount);
   }
 
-  // Function to withdraw unclaimed rewards after timeout period
+  // Function to withdraw unclaimed rewards after timeout period and cancel the event reward, if the reward have been claimed
   function withdrawUnclaimedRewards(uint256 _eventId) external {
     checkZeroAddress();
     checkEventIsValid(_eventId);

--- a/src/EventRewardManager.sol
+++ b/src/EventRewardManager.sol
@@ -29,7 +29,8 @@ contract EventRewardManager is Ownable {
   //Minimum wait time required before the unclaimed reward withdrawal operation can be performed
   uint256 public constant WITHDRAWAL_TIMEOUT = 30 days;
 
-  event TokenRewardCreated(
+
+event TokenRewardCreated(
     uint256 indexed eventId,
     address indexed eventManager,
     address tokenAddress,
@@ -48,6 +49,14 @@ contract EventRewardManager is Ownable {
   event TokenRewardCancelled(
     uint256 indexed eventId, address indexed eventManager, uint256 indexed amount
   );
+
+  event TokenRewardDistributed(uint256 indexed eventId, address indexed recipient, uint256 amount);
+
+  event MultipleTokenRewardDistributed(
+    uint256 indexed eventId, address[] indexed recipients, uint256[] amounts
+  );
+
+  event TokenRewardClaimed(uint256 indexed eventId, address indexed recipient, uint256 amount);
 
   constructor(address _eventManagerAddress) Ownable(msg.sender) {
     eventManager = EventManager(_eventManagerAddress);

--- a/test/EventRewardManager.t.sol
+++ b/test/EventRewardManager.t.sol
@@ -230,7 +230,6 @@ contract EventRewardManagerTest is Test {
       uint256 claimedAmount
     ) = rewardManager.eventTokenRewards(eventId);
 
-    
     assert(manager == owner);
     assert(tokenAddress == address(usdcToken));
     assert(tokenType == EventRewardManager.TokenType.USDC);

--- a/test/EventRewardManager.t.sol
+++ b/test/EventRewardManager.t.sol
@@ -54,13 +54,16 @@ contract EventRewardManagerTest is Test {
       address manager,
       address tokenAddress,
       EventRewardManager.TokenType tokenType,
-      uint256 eventRewardAmount
+      uint256 eventRewardAmount,
+      uint256 createdAt,
+      bool isCancelled
     ) = rewardManager.eventTokenRewards(eventId);
 
     assert(manager == owner);
     assert(tokenType == EventRewardManager.TokenType.USDC);
     assert(tokenAddress == address(usdcToken));
     assert(eventRewardAmount == rewardAmount);
+    assert(!isCancelled);
   }
 
   function testCreateTokenRewardZeroAddress() public {
@@ -119,9 +122,12 @@ contract EventRewardManagerTest is Test {
       address manager,
       address tokenAddress,
       EventRewardManager.TokenType tokenType,
-      uint256 eventRewardAmount
+      uint256 eventRewardAmount,
+      uint256 createdAt,
+      bool isCancelled
     ) = rewardManager.eventTokenRewards(eventId);
 
+    
     assert(manager == owner);
     assert(tokenAddress == address(usdcToken));
     assert(tokenType == EventRewardManager.TokenType.USDC);

--- a/test/EventRewardManager.t.sol
+++ b/test/EventRewardManager.t.sol
@@ -56,14 +56,17 @@ contract EventRewardManagerTest is Test {
       EventRewardManager.TokenType tokenType,
       uint256 eventRewardAmount,
       uint256 createdAt,
-      bool isCancelled
+      bool isCancelled,
+      uint256 claimedAmount
     ) = rewardManager.eventTokenRewards(eventId);
 
     assert(manager == owner);
     assert(tokenType == EventRewardManager.TokenType.USDC);
     assert(tokenAddress == address(usdcToken));
     assert(eventRewardAmount == rewardAmount);
+    assert(createdAt > 0);
     assert(!isCancelled);
+    assertEq(claimedAmount, 0);
   }
 
   function testCreateTokenRewardZeroAddress() public {
@@ -124,7 +127,8 @@ contract EventRewardManagerTest is Test {
       EventRewardManager.TokenType tokenType,
       uint256 eventRewardAmount,
       uint256 createdAt,
-      bool isCancelled
+      bool isCancelled,
+      uint256 claimedAmount
     ) = rewardManager.eventTokenRewards(eventId);
 
     

--- a/test/EventRewardManager.t.sol
+++ b/test/EventRewardManager.t.sol
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../src/EventManager.sol";
+import "../src/EventRewardManager.sol";
+
+contract EventRewardManagerTest is Test {
+  EventManager public eventManager;
+  EventRewardManager public rewardManager;
+  MockERC20 public usdcToken;
+  MockERC20 public wldToken;
+
+  address public owner;
+  address public participant;
+  uint256 eventId;
+  uint256 rewardAmount;
+
+  function setUp() public {
+    owner = address(this);
+    participant = address(0x1337);
+
+    usdcToken = new MockERC20("USDC", "USDC", 6);
+    wldToken = new MockERC20("WLD", "WLD", 18);
+
+    eventManager =
+      new EventManager(address(0x1234), 123_456_789, address(0x5678), "appId", "actionId");
+    rewardManager = new EventRewardManager(address(eventManager));
+
+    // Create event for testing
+    eventId = 0;
+    eventManager.createEvent("Devcon 2025", "Test Event", block.timestamp + 1 days, "USDC");
+
+    // Mint tokens to the test contract and approve the reward manager
+    rewardAmount = 1000 * 10 ** 6; // 1000 USDC
+    usdcToken.mint(address(this), rewardAmount);
+    usdcToken.approve(address(rewardManager), rewardAmount);
+  }
+
+  function testCreateTokenReward() public {
+    // Test event emitted as expected
+    vm.expectEmit(true, true, true, true);
+    emit EventRewardManager.TokenRewardCreated(
+      eventId, address(this), address(usdcToken), EventRewardManager.TokenType.USDC, rewardAmount
+    );
+
+    // Create event token reward
+    rewardManager.createTokenReward(
+      eventId, EventRewardManager.TokenType.USDC, address(usdcToken), rewardAmount
+    );
+
+    // Verify created reward amount
+    (
+      address manager,
+      address tokenAddress,
+      EventRewardManager.TokenType tokenType,
+      uint256 eventRewardAmount
+    ) = rewardManager.eventTokenRewards(eventId);
+
+    assert(manager == owner);
+    assert(tokenType == EventRewardManager.TokenType.USDC);
+    assert(tokenAddress == address(usdcToken));
+    assert(eventRewardAmount == rewardAmount);
+  }
+
+  function testCreateTokenRewardZeroAddress() public {
+    // Attempt to create a token reward with a zero address
+    vm.expectRevert("Zero token address detected");
+    rewardManager.createTokenReward(
+      eventId, EventRewardManager.TokenType.USDC, address(0), rewardAmount
+    );
+  }
+
+  function testCreateTokenRewardZeroAmount() public {
+    // Attempt to create a token reward with a zero reward amount
+    vm.expectRevert("Zero amount detected");
+    rewardManager.createTokenReward(
+      eventId, EventRewardManager.TokenType.USDC, address(usdcToken), 0
+    );
+  }
+
+  function testCreateTokenRewardInvalidTokenType() public {
+    // Attempt to create a token reward with an invalid token type
+    vm.expectRevert("Invalid token type");
+    rewardManager.createTokenReward(
+      eventId, EventRewardManager.TokenType.NFT, address(usdcToken), rewardAmount
+    );
+  }
+
+  function testCreateTokenRewardEventDoesNotExist() public {
+    uint256 invalidEventId = 420;
+
+    // Attempt to create a token reward for a non-existent event
+    vm.expectRevert("Event does not exist");
+    rewardManager.createTokenReward(
+      invalidEventId, EventRewardManager.TokenType.USDC, address(usdcToken), rewardAmount
+    );
+  }
+
+  function testUpdateTokenReward() public {
+    uint256 additionalReward = 500 * 10 ** 6;
+
+    // Create initial event token reward
+    rewardManager.createTokenReward(
+      eventId, EventRewardManager.TokenType.USDC, address(usdcToken), rewardAmount
+    );
+
+    // Mint more tokens to update event reward
+    usdcToken.mint(address(this), additionalReward);
+    usdcToken.approve(address(rewardManager), additionalReward);
+
+    // Test event emitted as expected
+    vm.expectEmit(true, true, true, true);
+    emit EventRewardManager.TokenRewardUpdated(eventId, address(this), additionalReward);
+    rewardManager.updateTokenReward(eventId, additionalReward);
+
+    // Verify the updated reward amount
+    (
+      address manager,
+      address tokenAddress,
+      EventRewardManager.TokenType tokenType,
+      uint256 eventRewardAmount
+    ) = rewardManager.eventTokenRewards(eventId);
+
+    assert(manager == owner);
+    assert(tokenAddress == address(usdcToken));
+    assert(tokenType == EventRewardManager.TokenType.USDC);
+    assert(eventRewardAmount == rewardAmount + additionalReward);
+  }
+
+  function testUpdateTokenRewardOnlyEventManager() public {
+    uint256 additionalReward = 500 * 10 ** 6;
+
+    rewardManager.createTokenReward(
+      eventId, EventRewardManager.TokenType.USDC, address(usdcToken), rewardAmount
+    );
+
+    // Attempt to update the token reward from a different address
+    address nonManager = address(0x666);
+    vm.prank(nonManager);
+    vm.expectRevert("Only event manager allowed");
+    rewardManager.updateTokenReward(eventId, additionalReward);
+  }
+
+  function testUpdateTokenRewardEventDoesNotExist() public {
+    uint256 invalidEventId = 999;
+    uint256 additionalReward = 500 * 10 ** 6;
+
+    // Attempt to update the token reward for a non-existent event
+    vm.expectRevert("Event does not exist");
+    rewardManager.updateTokenReward(invalidEventId, additionalReward);
+  }
+
+  function testDistributeTokenReward() public {
+    uint256 initialReward = 1000 * 10 ** 6;
+    uint256 participantReward = 100 * 10 ** 6;
+
+    rewardManager.createTokenReward(
+      eventId, EventRewardManager.TokenType.USDC, address(usdcToken), initialReward
+    );
+
+    // Distribute reward to participant
+    rewardManager.distributeTokenReward(eventId, participant, participantReward);
+
+    // Verify participant received correct token amount
+    assert(usdcToken.balanceOf(participant) == participantReward);
+  }
+
+  function testDistributeTokenRewardEventDoesNotExist() public {
+    uint256 invalidEventId = 1111;
+    uint256 participantReward = 100 * 10 ** 6;
+
+    rewardManager.createTokenReward(
+      eventId, EventRewardManager.TokenType.USDC, address(usdcToken), rewardAmount
+    );
+
+    // Attempt to distribute tokens for an event that does not exist
+    vm.expectRevert("Event does not exist");
+    rewardManager.distributeTokenReward(invalidEventId, participant, participantReward);
+  }
+
+  function testDistributeTokenRewardInsufficientRewardAmount() public {
+    uint256 participantReward = 1100 * 10 ** 6;
+
+    rewardManager.createTokenReward(
+      eventId, EventRewardManager.TokenType.USDC, address(usdcToken), rewardAmount
+    );
+
+    // Attempt to distribute more tokens than available in contract
+    vm.expectRevert("Insufficient reward amount");
+    rewardManager.distributeTokenReward(eventId, participant, participantReward);
+  }
+}
+
+// Mock ERC20 Token for Testing
+contract MockERC20 {
+  mapping(address => uint256) public balanceOf;
+  mapping(address => mapping(address => uint256)) public allowance;
+
+  string public name;
+  string public symbol;
+  uint8 public decimals;
+  uint256 public totalSupply;
+
+  constructor(string memory _name, string memory _symbol, uint8 _decimals) {
+    name = _name;
+    symbol = _symbol;
+    decimals = _decimals;
+  }
+
+  function mint(address to, uint256 amount) public {
+    balanceOf[to] += amount;
+    totalSupply += amount;
+  }
+
+  function transfer(address recipient, uint256 amount) public returns (bool) {
+    require(balanceOf[msg.sender] >= amount, "Insufficient balance");
+    balanceOf[msg.sender] -= amount;
+    balanceOf[recipient] += amount;
+    return true;
+  }
+
+  function transferFrom(address sender, address recipient, uint256 amount) public returns (bool) {
+    require(balanceOf[sender] >= amount, "Insufficient balance");
+    require(allowance[sender][msg.sender] >= amount, "Insufficient allowance");
+
+    balanceOf[sender] -= amount;
+    balanceOf[recipient] += amount;
+    allowance[sender][msg.sender] -= amount;
+
+    return true;
+  }
+
+  function approve(address spender, uint256 amount) public returns (bool) {
+    allowance[msg.sender][spender] = amount;
+    return true;
+  }
+}

--- a/test/EventRewardManager.t.sol
+++ b/test/EventRewardManager.t.sol
@@ -422,7 +422,7 @@ contract EventRewardManagerTest is Test {
     assertEq(rewardManager.getUserTokenReward(eventId, user2), 5, "User2 reward incorrect");
     assertEq(rewardManager.getUserTokenReward(eventId, user3), 5, "User3 reward incorrect");
 
-    (,,, uint256 remainingReward) = rewardManager.eventTokenRewards(eventId);
+    (,,, uint256 remainingReward,,,) = rewardManager.eventTokenRewards(eventId);
     assertEq(remainingReward, rewardAmount - 15, "Remaining reward incorrect");
   }
 

--- a/test/WithdrawUnclaimedReward.t.sol
+++ b/test/WithdrawUnclaimedReward.t.sol
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "./EventRewardManager.t.sol";
+
+contract WithdrawUnclaimedReward is EventRewardManagerTest {
+    function testWithdrawUnclaimedRewards() public {
+        //Create a token reward 
+        rewardManager.createTokenReward(
+            eventId,
+            EventRewardManager.TokenType.USDC,
+            address(usdcToken),
+            rewardAmount
+        );
+
+        //Fast forward time
+        vm.warp(block.timestamp + 31 days);
+
+        uint256 balanceBefore = usdcToken.balanceOf(address(this));
+        rewardManager.withdrawUnclaimedRewards(eventId);
+        uint256 balanceAfter = usdcToken.balanceOf(address(this));
+
+        assertEq(balanceAfter - balanceBefore, rewardAmount);
+    }
+
+    function testWithdrawBeforeTimeout() public {
+        rewardManager.createTokenReward(
+            eventId,
+            EventRewardManager.TokenType.USDC,
+            address(usdcToken),
+            rewardAmount
+        );
+
+        vm.expectRevert("Withdrawal timeout not reached");
+        rewardManager.withdrawUnclaimedRewards(eventId);
+    }
+
+    function testCancelAndReclaimReward() public {
+        rewardManager.createTokenReward(
+            eventId,
+            EventRewardManager.TokenType.USDC,
+            address(usdcToken),
+            rewardAmount
+        );
+
+        // Fast forward time
+        vm.warp(block.timestamp + 31 days);
+
+        uint256 balanceBefore = usdcToken.balanceOf(address(this));
+        rewardManager.cancelAndReclaimReward(eventId);
+        uint256 balanceAfter = usdcToken.balanceOf(address(this));
+
+        assertEq(balanceAfter - balanceBefore, rewardAmount);
+
+        (,,,uint256 remainingReward,,bool isCancelled) = rewardManager.eventTokenRewards(eventId);
+        assertEq(remainingReward, 0);
+        assertTrue(isCancelled);
+    }
+
+    function testCancelAndReclaimRewardBeforeTimeout() public {
+        rewardManager.createTokenReward(
+            eventId,
+            EventRewardManager.TokenType.USDC,
+            address(usdcToken),
+            rewardAmount
+        );
+
+        vm.expectRevert("Cancellation timeout not reached");
+        rewardManager.cancelAndReclaimReward(eventId);
+    }
+
+    function testCancelAndReclaimRewardTwice() public {
+        rewardManager.createTokenReward(
+            eventId,
+            EventRewardManager.TokenType.USDC,
+            address(usdcToken),
+            rewardAmount
+        );
+
+        // Fast forward time
+        vm.warp(block.timestamp + 31 days);
+
+        rewardManager.cancelAndReclaimReward(eventId);
+
+        vm.expectRevert("Event reward already cancelled");
+        rewardManager.cancelAndReclaimReward(eventId);
+    }
+}

--- a/test/WithdrawUnclaimedReward.t.sol
+++ b/test/WithdrawUnclaimedReward.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import "./EventRewardManager.t.sol";
 
 contract WithdrawUnclaimedReward is EventRewardManagerTest {
+    // Function to test withdraw unclaim rewards 
     function testWithdrawUnclaimedRewards() public {
         //Create a token reward 
         rewardManager.createTokenReward(
@@ -23,6 +24,7 @@ contract WithdrawUnclaimedReward is EventRewardManagerTest {
         assertEq(balanceAfter - balanceBefore, rewardAmount);
     }
 
+    // Function to test withdraw before the limited time 
     function testWithdrawBeforeTimeout() public {
         rewardManager.createTokenReward(
             eventId,
@@ -35,6 +37,7 @@ contract WithdrawUnclaimedReward is EventRewardManagerTest {
         rewardManager.withdrawUnclaimedRewards(eventId);
     }
 
+    // Function to test cancel and reclaim rewards 
     function testCancelAndReclaimReward() public {
         rewardManager.createTokenReward(
             eventId,
@@ -57,6 +60,7 @@ contract WithdrawUnclaimedReward is EventRewardManagerTest {
         assertTrue(isCancelled);
     }
 
+    // Function to test cancel and reclaim reward before the limited time
     function testCancelAndReclaimRewardBeforeTimeout() public {
         rewardManager.createTokenReward(
             eventId,
@@ -69,6 +73,7 @@ contract WithdrawUnclaimedReward is EventRewardManagerTest {
         rewardManager.cancelAndReclaimReward(eventId);
     }
 
+    // Function to test cancel and reclaim reward twice
     function testCancelAndReclaimRewardTwice() public {
         rewardManager.createTokenReward(
             eventId,

--- a/test/WithdrawUnclaimedReward.t.sol
+++ b/test/WithdrawUnclaimedReward.t.sol
@@ -63,9 +63,8 @@ contract WithdrawUnclaimedReward is EventRewardManagerTest {
     (,,, uint256 eventRewardAmount,, bool isCancelled, uint256 claimedAmount) =
       rewardManager.eventTokenRewards(eventId);
 
-    assertEq(eventRewardAmount, claimAmount, "Reward amount should equal claimed amount");
-    assertFalse(isCancelled, "Event should not be cancelled after partial withdrawal");
-    assertEq(claimedAmount, claimAmount, "Claimed amount should remain unchanged");
+    assertEq(eventRewardAmount, 0, "Reward amount should be 0 after full withdrawal");
+    assertTrue(isCancelled, "Event should be cancelled after full withdrawal");
   }
 
   // Function to test cancel and reclaim reward before the limited time

--- a/test/WithdrawUnclaimedReward.t.sol
+++ b/test/WithdrawUnclaimedReward.t.sol
@@ -4,119 +4,92 @@ pragma solidity ^0.8.20;
 import "./EventRewardManager.t.sol";
 
 contract WithdrawUnclaimedReward is EventRewardManagerTest {
-    // Function to test withdraw unclaim rewards 
-    function testWithdrawUnclaimedRewards() public {
-        //Create a token reward 
-        rewardManager.createTokenReward(
-            eventId,
-            EventRewardManager.TokenType.USDC,
-            address(usdcToken),
-            rewardAmount
-        );
+  // Function to test withdraw unclaim rewards
+  function testWithdrawUnclaimedRewards() public {
+    //Create a token reward
+    rewardManager.createTokenReward(
+      eventId, EventRewardManager.TokenType.USDC, address(usdcToken), rewardAmount
+    );
 
-        //Fast forward time
-        vm.warp(block.timestamp + 31 days);
+    //Fast forward time
+    vm.warp(block.timestamp + 31 days);
 
-        uint256 balanceBefore = usdcToken.balanceOf(address(this));
-        rewardManager.withdrawUnclaimedRewards(eventId);
-        uint256 balanceAfter = usdcToken.balanceOf(address(this));
+    uint256 balanceBefore = usdcToken.balanceOf(address(this));
+    rewardManager.withdrawUnclaimedRewards(eventId);
+    uint256 balanceAfter = usdcToken.balanceOf(address(this));
 
-        assertEq(balanceAfter - balanceBefore, rewardAmount);
+    assertEq(balanceAfter - balanceBefore, rewardAmount);
 
-        (
-            ,
-            ,
-            ,
-            uint256 eventRewardAmount,
-            ,
-            bool isCancelled,
-            uint256 claimedAmount
-        ) = rewardManager.eventTokenRewards(eventId);
+    (,,, uint256 eventRewardAmount,, bool isCancelled, uint256 claimedAmount) =
+      rewardManager.eventTokenRewards(eventId);
 
-        assertEq(eventRewardAmount, 0, "Reward amount should be 0 after full withdrawal");
-        assertTrue(isCancelled, "Event should be cancelled after full withdrawal");
-        assertEq(claimedAmount, 0, "Claimed amount should remain 0");
-    }
+    assertEq(eventRewardAmount, 0, "Reward amount should be 0 after full withdrawal");
+    assertTrue(isCancelled, "Event should be cancelled after full withdrawal");
+    assertEq(claimedAmount, 0, "Claimed amount should remain 0");
+  }
 
-    // Function to test withdraw before the limited time 
-    function testWithdrawBeforeTimeout() public {
-        rewardManager.createTokenReward(
-            eventId,
-            EventRewardManager.TokenType.USDC,
-            address(usdcToken),
-            rewardAmount
-        );
+  // Function to test withdraw before the limited time
+  function testWithdrawBeforeTimeout() public {
+    rewardManager.createTokenReward(
+      eventId, EventRewardManager.TokenType.USDC, address(usdcToken), rewardAmount
+    );
 
-        vm.expectRevert("Withdrawal timeout not reached");
-        rewardManager.withdrawUnclaimedRewards(eventId);
-    }
+    vm.expectRevert("Withdrawal timeout not reached");
+    rewardManager.withdrawUnclaimedRewards(eventId);
+  }
 
-    // Function to test partial withdraw unclaimed rewards
-    function testWithdrawUnclaimedRewardsPartial() public {
-        rewardManager.createTokenReward(
-            eventId,
-            EventRewardManager.TokenType.USDC,
-            address(usdcToken),
-            rewardAmount
-        );
+  // Function to test partial withdraw unclaimed rewards
+  function testWithdrawUnclaimedRewardsPartial() public {
+    rewardManager.createTokenReward(
+      eventId, EventRewardManager.TokenType.USDC, address(usdcToken), rewardAmount
+    );
 
-        uint256 claimAmount = rewardAmount / 2;
-        rewardManager.distributeTokenReward(eventId, participant, claimAmount);
+    uint256 claimAmount = rewardAmount / 2;
+    rewardManager.distributeTokenReward(eventId, participant, claimAmount);
 
-        // Fast forward time
-        vm.warp(block.timestamp + 31 days);
+    // Fast forward time
+    vm.warp(block.timestamp + 31 days);
 
-        uint256 initialBalance = usdcToken.balanceOf(address(this));
+    uint256 initialBalance = usdcToken.balanceOf(address(this));
 
-        rewardManager.withdrawUnclaimedRewards(eventId);
+    rewardManager.withdrawUnclaimedRewards(eventId);
 
-        uint256 finalBalance = usdcToken.balanceOf(address(this));
+    uint256 finalBalance = usdcToken.balanceOf(address(this));
 
-        assertEq(finalBalance - initialBalance, rewardAmount - claimAmount, "Incorrect withdrawal amount");
+    assertEq(
+      finalBalance - initialBalance, rewardAmount - claimAmount, "Incorrect withdrawal amount"
+    );
 
-        (
-            ,
-            ,
-            ,
-            uint256 eventRewardAmount,
-            ,
-            bool isCancelled,
-            uint256 claimedAmount
-        ) = rewardManager.eventTokenRewards(eventId);
+    (,,, uint256 eventRewardAmount,, bool isCancelled, uint256 claimedAmount) =
+      rewardManager.eventTokenRewards(eventId);
 
-        assertEq(eventRewardAmount, claimAmount, "Reward amount should equal claimed amount");
-        assertFalse(isCancelled, "Event should not be cancelled after partial withdrawal");
-        assertEq(claimedAmount, claimAmount, "Claimed amount should remain unchanged");
-    }
+    assertEq(eventRewardAmount, claimAmount, "Reward amount should equal claimed amount");
+    assertFalse(isCancelled, "Event should not be cancelled after partial withdrawal");
+    assertEq(claimedAmount, claimAmount, "Claimed amount should remain unchanged");
+  }
 
-    // Function to test cancel and reclaim reward before the limited time
-    function testCancelAndReclaimRewardBeforeTimeout() public {
-        rewardManager.createTokenReward(
-            eventId,
-            EventRewardManager.TokenType.USDC,
-            address(usdcToken),
-            rewardAmount
-        );
+  // Function to test cancel and reclaim reward before the limited time
+  function testCancelAndReclaimRewardBeforeTimeout() public {
+    rewardManager.createTokenReward(
+      eventId, EventRewardManager.TokenType.USDC, address(usdcToken), rewardAmount
+    );
 
-        vm.expectRevert("Withdrawal timeout not reached");
-        rewardManager.withdrawUnclaimedRewards(eventId);
-    }
+    vm.expectRevert("Withdrawal timeout not reached");
+    rewardManager.withdrawUnclaimedRewards(eventId);
+  }
 
-    // Function to test withdraw unclaim rewards for someone who isn't the event manager
-    function testWithdrawUnclaimedRewardsNonManager() public {
-        rewardManager.createTokenReward(
-            eventId,
-            EventRewardManager.TokenType.USDC,
-            address(usdcToken),
-            rewardAmount
-        );
+  // Function to test withdraw unclaim rewards for someone who isn't the event manager
+  function testWithdrawUnclaimedRewardsNonManager() public {
+    rewardManager.createTokenReward(
+      eventId, EventRewardManager.TokenType.USDC, address(usdcToken), rewardAmount
+    );
 
-        // Fast forward time
-        vm.warp(block.timestamp + 31 days);
+    // Fast forward time
+    vm.warp(block.timestamp + 31 days);
 
-        address nonManager = address(0x1234);
-        vm.prank(nonManager);
-        vm.expectRevert("Only event manager allowed");
-        rewardManager.withdrawUnclaimedRewards(eventId);
-    }
+    address nonManager = address(0x1234);
+    vm.prank(nonManager);
+    vm.expectRevert("Only event manager allowed");
+    rewardManager.withdrawUnclaimedRewards(eventId);
+  }
 }

--- a/test/WithdrawUnclaimedReward.t.sol
+++ b/test/WithdrawUnclaimedReward.t.sol
@@ -102,7 +102,7 @@ contract WithdrawUnclaimedReward is EventRewardManagerTest {
         rewardManager.withdrawUnclaimedRewards(eventId);
     }
 
-    // Function to test withdraw unclaim rewards for someone who is not the event manager
+    // Function to test withdraw unclaim rewards for someone who isn't the event manager
     function testWithdrawUnclaimedRewardsNonManager() public {
         rewardManager.createTokenReward(
             eventId,


### PR DESCRIPTION
## How I Fixed The Issue

- Modified the struct, adding `createdAt` and `isCanclled` to the structure.
- Defined a constant variable of the wait time required before the unclaimed reward withdrawal operation. 
- Added events for the `TokenRewardWithdrawn` and `TokenRewardCancelled`.
- I created and implemented the `withdrawUnclaimedRewards` function.
- I created and implemented the `cancelAndReclaimReward` function.
- Wrote the unit testing for the functions 